### PR TITLE
Correct check "if netns exists"

### DIFF
--- a/if-pre-up.d/netns
+++ b/if-pre-up.d/netns
@@ -5,7 +5,7 @@ set -e
 if [ -n "${IF_PEER_NETNS}" -a -n "${IF_PEER_IFACE}" ]
 then
 	# Create netns if it doesn't already exist, and bring up the loopback
-	if ! (ip netns list | grep -qx ${IF_PEER_NETNS})
+	if ! (ip netns list | grep -qw "^${IF_PEER_NETNS}")
 	then
 		mkdir -p /run/network.${IF_PEER_NETNS}
 		rm -rf /run/network.${IF_PEER_NETNS}/*


### PR DESCRIPTION
Debian 9 stretch:
`ip netns list`  
`myns (id: 0)`